### PR TITLE
Fix unreachable code after raising exception

### DIFF
--- a/octoffers/platforms/ziprecruiter.py
+++ b/octoffers/platforms/ziprecruiter.py
@@ -45,9 +45,8 @@ class ZipRecruiter(Driver):
                     lambda driver: driver.find_elements(By.CLASS_NAME, "job_result_two_pane_v2")
                 )
             except TimeoutException as e:
-                raise e
                 log.error("Couldn't find any job postings, please check your search parameters.")
-                return
+                raise e
             # Remove annoying pop-up
             self.driver.execute_script("document.querySelector('body > div[data-focus-lock-disabled=false]').remove(document.querySelector('body > div[data-focus-lock-disabled=false] > div'))")
             


### PR DESCRIPTION
In the `fetch` method of `ZipRecruiter`, a `TimeoutException` was being raised before the error logging and return statements, making them unreachable. This PR moves the log statement before the `raise e` call.

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.